### PR TITLE
[Fix] __toString() methods return

### DIFF
--- a/src/Concrete/Mautic/Tracker.php
+++ b/src/Concrete/Mautic/Tracker.php
@@ -67,5 +67,6 @@ class Tracker extends Asset
     mt('send', 'pageview', %s);
 </script>", $this->url, json_encode($this->parameters));
         }
+        return '';
     }
 }


### PR DESCRIPTION
This commit fixes the following error-
`
Whoops \ Exception \ ErrorException (E_RECOVERABLE_ERROR)
Method Concrete\Package\MauticTracker\Mautic\Tracker::__toString() must return a string value
`